### PR TITLE
Changes the name of the IIFE filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.8",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
-  "iife": "dist/index.js",
+  "iife": "dist/global-nav.js",
   "scripts": {
     "build": "rm -rf dist && rollup -c",
     "lint": "yarn sass-lint src/**/*.scss -v && yarn eslint src/js",


### PR DESCRIPTION
# Done
Changed the name of the IIFE script.
This way it becomes a lot easier for external projects to include both the script and the source-map, the mapping of which is baked into the script with `//# sourceMappingURL=$SCRIPTNAME.js.map`.

Using the generic `index.js` can easily lead to problems and would require more complicated build steps in implementing projects.

Fixes  https://github.com/canonical-web-and-design/global-nav/issues/102 