### PR TITLE
Fix .forEach error on older browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -1,5 +1,11 @@
 import { canonicalProducts } from './product-details';
 
+function forEach(array, callback, scope) {
+  for (let i = 0; i < array.length; i += 1) {
+    callback.call(scope, i, array[i]);
+  }
+}
+
 function createFromHTML(html) {
   const div = window.document.createElement('div'); //eslint-disable-line
   div.innerHTML = html;
@@ -209,7 +215,7 @@ function addListeners(breakpoint, wrapper) {
 
   function closeNav() {
     dropdownContainer.classList.remove('show-content');
-    headerLinks.forEach(link => link.classList.remove('is-selected'));
+    forEach(headerLinks, (_, link) => link.classList.remove('is-selected'));
     overlay.classList.remove('show-overlay');
   }
 
@@ -225,8 +231,10 @@ function addListeners(breakpoint, wrapper) {
     const targetMenu = wrapper.querySelector(targetMenuId);
 
     headerLink.classList.add('is-selected');
-    dropdownContents.forEach(
-      menu => menu !== targetMenu && menu.classList.add('u-hide')
+
+    forEach(
+      dropdownContents,
+      (_, menu) => menu !== targetMenu && menu.classList.add('u-hide')
     );
     targetMenu.classList.remove('u-hide');
     overlay.classList.add('show-overlay');
@@ -236,7 +244,7 @@ function addListeners(breakpoint, wrapper) {
     }
   }
 
-  headerLinks.forEach(headerLink => {
+  forEach(headerLinks, (_, headerLink) => {
     headerLink.addEventListener('click', e => {
       e.preventDefault();
 
@@ -244,7 +252,9 @@ function addListeners(breakpoint, wrapper) {
         if (headerLink.classList.contains('is-selected')) {
           closeNav();
         } else {
-          headerLinks.forEach(link => link.classList.remove('is-selected'));
+          forEach(headerLinks, (__, link) =>
+            link.classList.remove('is-selected')
+          );
           openDropdown(headerLink);
         }
       } else {
@@ -254,7 +264,7 @@ function addListeners(breakpoint, wrapper) {
     });
   });
 
-  expandingRows.forEach(expandingRow => {
+  forEach(expandingRows, (_, expandingRow) => {
     expandingRow.addEventListener('click', e => {
       e.target.classList.toggle('is-active');
       scrollGlobalNavToTop();


### PR DESCRIPTION
## Done

Replaced ES6 `forEach` with a similarly named helper function

## QA
- The error can be easily seen/reproduced in Firefox 45 (as reported in [Sentry](https://sentry.is.canonical.com/canonical/jaas-ai/issues/2856/?query=is%3Aunresolved)), so consider installing the appropriate version from https://ftp.mozilla.org/pub/firefox/releases/45.0/, then `./run` the master branch and inspect the console/see that the dropdown nav does not work.
- Check out this branch
- `./run` the project again
- See that the console error is gone, and the dropdown nav works
- Remove the ancient version of Firefox

Fixes #122 

