### PR TITLE
Add hiring link

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For example, to set the `max-width` to `80rem`:
 </script>
 ```
 
-- `hiring`: A link to a hiring page which will display a link in the header to the job page (default: `false`)
+- `hiring`: A URL for a hiring page which will display a link in the header to the job page (default: `false`)
 
 For example, to set the `hiring` to `https://boards.greenhouse.io/canonical/jobs/1586585`
 

--- a/README.md
+++ b/README.md
@@ -57,12 +57,22 @@ For example, to set the `max-width` to `80rem`:
 </script>
 ```
 
-If you're importing;
+- `hiring`: A link to a hiring page which will display a link in the header to the job page (default: `false`)
 
-```js
-import { createNav } from '@canonical/global-nav';
+For example, to set the `hiring` to `https://boards.greenhouse.io/canonical/jobs/1586585`
+
+````html
+<script src="/node_modules/@canonical/global-nav/dist/index.js"></script>
+
+<script>
+  canonicalGlobalNav.createNav({
+    hiring: 'https://boards.greenhouse.io/canonical/jobs/1586585',
+  });
+</script>
+
+If you're importing; ```js import { createNav } from '@canonical/global-nav';
 createNav({ maxWidth: '80rem' });
-```
+````
 
 ## Building the Global nav
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For example, to set the `max-width` to `80rem`:
 
 For example, to set the `hiring` to `https://boards.greenhouse.io/canonical/jobs/1586585`
 
-````html
+```html
 <script src="/node_modules/@canonical/global-nav/dist/index.js"></script>
 
 <script>
@@ -69,10 +69,14 @@ For example, to set the `hiring` to `https://boards.greenhouse.io/canonical/jobs
     hiring: 'https://boards.greenhouse.io/canonical/jobs/1586585',
   });
 </script>
+```
 
-If you're importing; ```js import { createNav } from '@canonical/global-nav';
+If you're importing;
+
+```js
+import { createNav } from '@canonical/global-nav';
 createNav({ maxWidth: '80rem' });
-````
+```
 
 ## Building the Global nav
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -204,7 +204,9 @@ function createProductDropdown(products) {
 }
 
 function addListeners(breakpoint, wrapper) {
-  const headerLinks = wrapper.querySelectorAll('.global-nav__header-link');
+  const headerLinks = wrapper.querySelectorAll(
+    '.global-nav__header-link.has-dropdown'
+  );
   const dropdownContainer = wrapper.querySelector('.global-nav__dropdown');
   const dropdownContents = wrapper.querySelectorAll(
     '.global-nav__dropdown-content'
@@ -274,7 +276,30 @@ function addListeners(breakpoint, wrapper) {
   overlay.addEventListener('click', closeNav);
 }
 
-export const createNav = ({ maxWidth = '68rem' } = {}) => {
+function validURL(str) {
+  let pattern = new RegExp(
+    '^(https?:\\/\\/)?' + // protocol
+    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+    '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+    '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string¬
+      '(\\#[-a-z\\d_]*)?$',
+    'i'
+  ); // fragment locator
+  return !!pattern.test(str);
+}
+
+function renderWereHiring(hiring) {
+  if (!hiring || !validURL(hiring)) {
+    return '';
+  }
+
+  return `<li class="global-nav__header-link">
+    <a class="global-nav__header-link-anchor" href="${hiring}">We are hiring</a>
+  </li>`;
+}
+
+export const createNav = ({ maxWidth = '68rem', hiring = false } = {}) => {
   // Recruitment call to action
   // eslint-disable-next-line no-console
   console.log(
@@ -298,7 +323,8 @@ export const createNav = ({ maxWidth = '68rem' } = {}) => {
         </a>
       </div>
       <ul class="global-nav__header-list">
-        <li class="global-nav__header-link">
+        ${renderWereHiring(hiring)}
+        <li class="global-nav__header-link has-dropdown">
           <a class="global-nav__header-link-anchor" href="#canonical-products">Products</a>
         </li>
       </ul>

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -276,21 +276,8 @@ function addListeners(breakpoint, wrapper) {
   overlay.addEventListener('click', closeNav);
 }
 
-function validURL(str) {
-  const pattern = new RegExp(
-    '^(https?:\\/\\/)?' + // protocol
-    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-    '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-    '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string¬
-      '(\\#[-a-z\\d_]*)?$',
-    'i'
-  ); // fragment locator
-  return !!pattern.test(str);
-}
-
 function renderWereHiring(hiring) {
-  if (!hiring || !validURL(hiring)) {
+  if (!hiring) {
     return '';
   }
 

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -277,7 +277,7 @@ function addListeners(breakpoint, wrapper) {
 }
 
 function validURL(str) {
-  let pattern = new RegExp(
+  const pattern = new RegExp(
     '^(https?:\\/\\/)?' + // protocol
     '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
     '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address

--- a/src/sass/global-nav.scss
+++ b/src/sass/global-nav.scss
@@ -91,12 +91,16 @@ $global-nav-overlay-color: rgba(17, 17, 17, 0.4);
     display: inline-block;
     line-height: 1.25rem;
     margin-bottom: 0;
-    padding: 0.375rem 1.625rem 0.375rem 0.5rem;
+    padding: 0.375rem 0.5rem;
     text-decoration: none;
 
     @media (max-width: $global-nav-breakpoint) {
       padding-left: 0;
     }
+  }
+
+  .has-dropdown .global-nav__header-link-anchor {
+    padding: 0.375rem 1.625rem 0.375rem 0.5rem;
 
     &::after {
       @include vf-animation(transform, snap);


### PR DESCRIPTION
## Done
Added a hiring link option to the list of link in the global nav.
Added README usage docs
Bump the version to 2.3.0

## QA
- Run `./run`
- Open http://172.17.0.4:8300/
- Check there is no difference and no hiring link
- Open the index.html file
- Update the `createNav` function with the following:
``` html
<script>
  canonicalGlobalNav.createNav({
    hiring: 'https://boards.greenhouse.io/canonical/jobs/1586585',
  });
</script>
```
- Reload the page and check you see the "We are hiring" link on the footer
- Check the hiring value to something other then a link
- Reload and check it doesn't render the link

## Screenshot
![Screenshot_2019-11-14 Canonical global navigation demo](https://user-images.githubusercontent.com/1413534/68789933-4bf04d00-063e-11ea-81e3-258bfcc4e018.png)
