### PR TITLE
Remove shop.ubuntu.com from global nav

### DIFF
--- a/src/js/product-details.js
+++ b/src/js/product-details.js
@@ -219,10 +219,6 @@ const canonicalProducts = {
       url: 'https://partners.ubuntu.com/',
     },
     {
-      title: 'Merchandise',
-      url: 'https://shop.canonical.com/',
-    },
-    {
       title: 'Contact',
       url: 'https://ubuntu.com/about/contact-us',
     },


### PR DESCRIPTION
Removes shop.ubuntu.com from global nav

### QA
1. pull this down
2. build it
3. see that 'Merchandise' has been removed

Fixes #137 