### PR TITLE
Remove bottom body padding

### DIFF
--- a/src/sass/global-nav.scss
+++ b/src/sass/global-nav.scss
@@ -392,11 +392,6 @@ $global-nav-overlay-color: rgba(17, 17, 17, 0.4);
 }
 
 @media (max-width: $global-nav-breakpoint) {
-  body {
-    padding-bottom: 3rem;
-    position: relative;
-  }
-
   .u-hide--mobile {
     display: none;
   }


### PR DESCRIPTION
Global nav doesn't move to bottom of the page on small screens, but still adds padding to the bottom of the page to make space for itself.

This PR fixes that.

### QA

- make sure there is no additional padding on bottom of the page on small screens