### PR TITLE
Update global-nav.js to add landmark role to skip link

### DIFF
--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -295,7 +295,7 @@ export const createNav = ({ maxWidth = '68rem', hiring = false } = {}) => {
 
   // Build global nav components
   const skipLink = createFromHTML(
-    '<div class="skip-content"><a href="#main-content">Skip to main content</a></div'
+    '<div class="skip-content" role="navigation"><a href="#main-content">Skip to main content</a></div'
   );
   const wrapper = createFromHTML(
     '<div id="canonical-global-nav" class="global-nav" role="complementary"></div>'


### PR DESCRIPTION
This skip link is currently failing accessibility best practice as it inserts into pages outside defined landmark areas.

<img width="491" alt="Screenshot 2020-09-23 at 10 58 16" src="https://user-images.githubusercontent.com/505570/93997915-cf64e980-fd8b-11ea-9dea-4e470497e7fd.png">

This change identifies the skip link to screen readers as navigation.

Ref: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role