### PR TITLE
change text of /advantage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/product-details.js
+++ b/src/js/product-details.js
@@ -80,7 +80,7 @@ const canonicalProducts = {
       links: [
         {
           url: 'http://ubuntu.com/advantage',
-          text: 'UA dashboard',
+          text: 'Your subscriptions',
         },
         {
           url: 'https://support.canonical.com/',


### PR DESCRIPTION
# Done
Changed /advantage link text from "UA dashboard" to "Your subscriptions" per the request [here](https://docs.google.com/document/d/1K65n3NpZCh7EWDXKLhG31seGJ2jKbW6lqw3BwV2mlnU/edit#heading=h.e8bamd1isn8i), and bumped the version one minor point

# QA
Verify the copy change in the file, or you could [run the project locally](https://github.com/canonical-web-and-design/global-nav#building-the-global-nav) and verify in the browser.
