### PR TITLE
Fix spacing issue global nav

### DIFF
--- a/src/sass/global-nav.scss
+++ b/src/sass/global-nav.scss
@@ -343,7 +343,7 @@ $global-nav-overlay-color: rgba(17, 17, 17, 0.4);
 
   .global-nav__inline-list {
     margin: 0.5rem 0 0 0;
-    padding: 0 0 1rem 2.75rem;
+    padding: 0 0 0 2.75rem;
 
     @media (max-width: $global-nav-breakpoint) {
       margin-top: 0;


### PR DESCRIPTION
## Done

- Fix padding issue on list item in global nav - description [here](https://github.com/canonical-web-and-design/global-nav/issues/173#issue-872429384)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://127.0.0.1:8300/
- Select the products drop down
- See the spacing looks more even


## Issue / Card

Fixes #173 

## Screenshot

[Before]

<img width="1170" alt="Screenshot 2021-04-30 at 12 21 07" src="https://user-images.githubusercontent.com/36884067/116688519-b9b54380-a9ae-11eb-9f36-3235bc593ec9.png">

<img width="1198" alt="Screenshot 2021-04-30 at 12 21 26" src="https://user-images.githubusercontent.com/36884067/116688509-b4f08f80-a9ae-11eb-9ac5-3652a7174b36.png">

[After]

![Screenshot 2021-06-01 at 16 24 20](https://user-images.githubusercontent.com/58959073/120349269-df0ed780-c2f5-11eb-94b6-c9c614efa68c.png)

![Screenshot 2021-06-01 at 16 24 53](https://user-images.githubusercontent.com/58959073/120349320-edf58a00-c2f5-11eb-821b-beaf81d00b09.png)



