### PR TITLE
Add start script so it can be run with dotrun snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ node_modules
 dist
 npm-debug.log
 package-lock.json
+
+# Project-specific ignores
+.dotrun.json

--- a/README.md
+++ b/README.md
@@ -82,10 +82,22 @@ createNav({ maxWidth: '80rem' });
 
 To build the JS into the `/dist` folder, run:
 
-##implest way to run the site locally is to first [install Docker](https://docs.docker.com/engine/installation/) (on Linux you may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)), and then use the `./run` script:
+```bash
+./run build
+```
+
+## Running the project locally
+
+The simplest way to run the site locally is to first [install Docker](https://docs.docker.com/engine/installation/) (on Linux you may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)), and then use the `./run` script:
 
 ```bash
 ./run
+```
+
+You can also use the [dotrun snap](https://snapcraft.io/dotrun), by running:
+
+```bash
+dotrun
 ```
 
 Once the containers are setup, you can visit <http://127.0.0.1:8300> in your browser.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "yarn sass-lint src/**/*.scss -v && yarn eslint src/js && prettier **/* --check",
     "prepublishonly": "npm run build",
     "watch": "rollup -c -w",
-    "clean": "rm -rf node_modules && rm -rf dist"
+    "clean": "rm -rf node_modules && rm -rf dist",
+    "start": "yarn run build && yarn run serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Done
I was trying to QA a [dependency update](https://github.com/canonical-web-and-design/global-nav/pull/190) and couldn't get the project running locally, so did this.

- Added `start` script to package.json, so the project can be run with `dotrun` command.

## QA

- Pull this branch
- `dotrun` the project
- visit http://127.0.0.1:8300/ and see that the global-nav demo is running