### PR TITLE
Global nav A11Y workshop fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <body>
     <main id="main-content">
       <h1>Page content</h1>
+      <button>Focus test</button>
       <p>
         This is the demo of the global navigation project for Canonical's
         websites.

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -35,25 +35,25 @@ function createMobileDropdown(products) {
 
   const mobileDropdown = `<div class="global-nav__mobile-strip">
       <div class="global-nav__row">
-        <h5 class="global-nav__muted-heading global-nav__expanding-row">Products</h5>
+        <h3 class="global-nav__muted-heading global-nav__expanding-row">Products</h3>
         <ul class="global-nav__split-list">
           ${mobileFlagships}
         </ul>
       </div>
       <div class="global-nav__row">
-        <h5 class="global-nav__muted-heading global-nav__expanding-row">Also from Canonical</h5>
+        <h3 class="global-nav__muted-heading global-nav__expanding-row">Also from Canonical</h3>
         <ul class="global-nav__split-list">
           ${mobileOthers}
         </ul>
       </div>
       <div class="global-nav__row">
-        <h5 class="global-nav__muted-heading global-nav__expanding-row">Resources</h5>
+        <h3 class="global-nav__muted-heading global-nav__expanding-row">Resources</h3>
         <ul class="global-nav__split-list">
           ${mobileResources}
         </ul>
       </div>
       <div class="global-nav__row">
-        <h5 class="global-nav__muted-heading global-nav__expanding-row">About</h5>
+        <h3 class="global-nav__muted-heading global-nav__expanding-row">About</h3>
         <ul class="global-nav__split-list u-no-margin--bottom">
           ${mobileAbouts}
         </ul>
@@ -181,17 +181,17 @@ function createProductDropdown(products) {
       <div class="global-nav__row">
         <div class="global-nav__flex-container">
           <div class="global-nav__others-col">
-            <h5 class="global-nav__muted-heading">Also from Canonical</h5>
+            <h3 class="global-nav__muted-heading">Also from Canonical</h3>
             <div class="global-nav__matrix">
               ${productOthers}
             </div>
           </div>
           <div class="global-nav__resources-col">
-            <h5 class="global-nav__muted-heading">Resources</h5>
+            <h3 class="global-nav__muted-heading">Resources</h3>
             <ul class="global-nav__split-list">
               ${productResources}
             </ul>
-            <h5 class="global-nav__muted-heading">About</h5>
+            <h3 class="global-nav__muted-heading">About</h3>
             <ul class="global-nav__split-list">
               ${productAbouts}
             </ul>
@@ -217,10 +217,19 @@ function addListeners(breakpoint, wrapper) {
 
   function closeNav() {
     dropdownContainer.classList.remove('show-content');
-    forEach(headerLinks, (_, link) => link.classList.remove('is-selected'));
+
+    forEach(headerLinks, (_, link) => {
+      link.classList.remove('is-selected');
+      const anchor = link.querySelector('.global-nav__header-link-anchor');
+      if (anchor) {
+        anchor.setAttribute('aria-expanded', 'false');
+      }
+    });
+
     forEach(dropdownContents, (_, menu) =>
       menu.setAttribute('aria-hidden', 'true')
     );
+
     // we are hiding dropdown content after the animation
     // to prevent it from being focusable
     // 500ms is hardcoded here, which should be enough for
@@ -230,6 +239,7 @@ function addListeners(breakpoint, wrapper) {
         menu.classList.add('u-hide');
       });
     }, 500);
+
     overlay.classList.remove('show-overlay');
   }
 
@@ -245,8 +255,7 @@ function addListeners(breakpoint, wrapper) {
     const targetMenu = wrapper.querySelector(targetMenuId);
 
     headerLink.classList.add('is-selected');
-
-    console.log(targetMenu);
+    targetMenuLink.setAttribute('aria-expanded', 'true');
 
     forEach(dropdownContents, (_, menu) => {
       if (menu !== targetMenu) {
@@ -331,7 +340,7 @@ export const createNav = ({ maxWidth = '68rem', hiring = false } = {}) => {
       <ul class="global-nav__header-list">
         ${renderWereHiring(hiring)}
         <li class="global-nav__header-link has-dropdown">
-          <a class="global-nav__header-link-anchor" href="#canonical-products">Products</a>
+          <a class="global-nav__header-link-anchor" aria-expanded="false" aria-controls="canonical-products" href="#canonical-products">Products</a>
         </li>
       </ul>
     </div>

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -218,6 +218,18 @@ function addListeners(breakpoint, wrapper) {
   function closeNav() {
     dropdownContainer.classList.remove('show-content');
     forEach(headerLinks, (_, link) => link.classList.remove('is-selected'));
+    forEach(dropdownContents, (_, menu) =>
+      menu.setAttribute('aria-hidden', 'true')
+    );
+    // we are hiding dropdown content after the animation
+    // to prevent it from being focusable
+    // 500ms is hardcoded here, which should be enough for
+    // most of Vanilla animation speeds
+    setTimeout(() => {
+      forEach(dropdownContents, (_, menu) => {
+        menu.classList.add('u-hide');
+      });
+    }, 500);
     overlay.classList.remove('show-overlay');
   }
 
@@ -234,11 +246,18 @@ function addListeners(breakpoint, wrapper) {
 
     headerLink.classList.add('is-selected');
 
-    forEach(
-      dropdownContents,
-      (_, menu) => menu !== targetMenu && menu.classList.add('u-hide')
-    );
+    console.log(targetMenu);
+
+    forEach(dropdownContents, (_, menu) => {
+      if (menu !== targetMenu) {
+        menu.classList.add('u-hide');
+        menu.setAttribute('aria-hidden', 'true');
+      }
+    });
+
     targetMenu.classList.remove('u-hide');
+    targetMenu.setAttribute('aria-hidden', 'false');
+
     overlay.classList.add('show-overlay');
 
     if (isMobile) {
@@ -320,7 +339,7 @@ export const createNav = ({ maxWidth = '68rem', hiring = false } = {}) => {
 
   const navDropdown = createFromHTML(
     `<div class="global-nav__dropdown">
-      <div class="global-nav__dropdown-content u-hide" id="canonical-products" style="max-width:${maxWidth}">
+      <div class="global-nav__dropdown-content u-hide" aria-hidden="true" id="canonical-products" style="max-width:${maxWidth}">
         ${createProductDropdown(canonicalProducts)}
       </div>
     </div>`

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -94,7 +94,7 @@ function createProductDropdown(products) {
 
       let flagshipMarkup = `<li class="global-nav__matrix-item">
           <a class="global-nav__link" href=${flagship.url}>
-            <img class="global-nav__matrix-image" src=${flagship.logoUrl} width="32" height="32" alt="icon">
+            <img class="global-nav__matrix-image" src=${flagship.logoUrl} width="32" height="32" alt="">
             <h4 class="global-nav__matrix-title">${flagship.title}&nbsp;&rsaquo;</h4>
           </a>
           <div class="global-nav__matrix-content">


### PR DESCRIPTION
Done:
- 'Products' menu button now correctly uses `aria-expanded` when changing state
- Headers in products menu dropdown now follow the hierarchy better
- When menu dropdown is closed it wont focus or be announced by screen reader

### QA

- Demo: https://global-nav-194.demos.haus
- Make sure global nav works as expected
- Navigate using Tab key and make sure that closed global nav is not accessible
- navigate using screen reader and make sure products menu works as expected
