### PR TITLE
Fix spacing issue below login link

### DIFF
--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -87,9 +87,9 @@ function createProductDropdown(products) {
       let linkList = '';
 
       if (flagship.links) {
-        linkList = `<ul class="global-nav__inline-list">
+        linkList = `<ul class="global-nav__inline-list .u-no-padding--bottom">
           ${createLinkListItems(flagship)}
-        <ul>`;
+        </ul>`;
       }
 
       let flagshipMarkup = `<li class="global-nav__matrix-item">
@@ -122,9 +122,9 @@ function createProductDropdown(products) {
       let linkList = '';
 
       if (other.links) {
-        linkList = `<ul class="global-nav__inline-list u-no-padding--left">
+        linkList = `<ul class="global-nav__inline-list .u-no-padding--bottom u-no-padding--left">
           ${createLinkListItems(other)}
-        <ul>`;
+        </ul>`;
       }
 
       let otherMarkup = `<li class="global-nav__matrix-item">


### PR DESCRIPTION
The conversation about the original issue can be found [here](https://github.com/canonical-web-and-design/global-nav/issues/199)

## Work done

- removed the empty <ul> element below the login link **note** the <ul> element is still there but no longer taking the space
- added u-no-padding--bottom to the global-nav__inline-list elements

## QA

- Go to [demo](https://global-nav-206.demos.haus/) and check there isn't an empty <ul> element below the 'login' link for snapcraft

## Issue

fixes https://github.com/canonical-web-and-design/global-nav/issues/199

