### PR TITLE
WD-26280 - Fix listeners removal and styling of link arrows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/sliding/listeners.js
+++ b/src/js/sliding/listeners.js
@@ -102,7 +102,6 @@ const expandDropdown = (
 };
 
 export const setUpListeners = (
-  breakpoint,
   closeDesktopGlobalNav,
   closeMenuAnimationDuration
 ) => {
@@ -281,7 +280,5 @@ export const setUpListeners = (
   // eslint-disable-next-line no-undef
   document.addEventListener('click', handleClickOutsideNavigation);
 
-  return {
-    addListeners,
-  };
+  return addListeners;
 };

--- a/src/js/sliding/listeners.js
+++ b/src/js/sliding/listeners.js
@@ -1,5 +1,3 @@
-import { debounce } from '../utils';
-
 const ANIMATION_SNAP_DURATION = 100;
 
 const setActiveDropdown = (dropdownToggleButton, isActive = true) => {

--- a/src/js/sliding/listeners.js
+++ b/src/js/sliding/listeners.js
@@ -214,8 +214,6 @@ export const setUpListeners = (
     }
   };
 
-  // needed to be able to remove the listeners
-  const toggleHandlerFunctions = [];
   const handleToggle = (e, toggle) => {
     e.preventDefault();
 
@@ -248,7 +246,6 @@ export const setUpListeners = (
     e.stopPropagation();
   };
 
-  const dropdownNavListsHandlers = [];
   const handleDropdownNavList = (e, dropdown) => {
     if (
       e.shiftKey &&
@@ -261,7 +258,6 @@ export const setUpListeners = (
     }
   };
 
-  const goBackOneLevelHandlers = [];
   const handleGoBackOneLevel = (e, backButton) => {
     goBackOneLevel(e, backButton);
   };
@@ -270,64 +266,17 @@ export const setUpListeners = (
     menuButton.addEventListener('click', handleMenuButtonClick);
     toggles.forEach(toggle => {
       const handler = e => handleToggle(e, toggle);
-      toggleHandlerFunctions.push(handler);
       toggle.addEventListener('click', handler);
     });
     dropdownNavLists.forEach(dropdown => {
       const handler = e => handleDropdownNavList(e, dropdown);
-      dropdownNavListsHandlers.push(handler);
       dropdown.children[1].addEventListener('keydown', handler);
     });
     // eslint-disable-next-line no-undef
     document.querySelectorAll('.js-back-button').forEach(backButton => {
       const handler = e => handleGoBackOneLevel(e, backButton);
-      goBackOneLevelHandlers.push(handler);
       backButton.addEventListener('click', handler);
     });
-  };
-
-  const removeListeners = () => {
-    menuButton.removeEventListener('click', handleMenuButtonClick);
-    // eslint-disable-next-line no-undef
-    toggles.forEach(toggle => {
-      const handler = toggleHandlerFunctions.shift();
-      toggle.removeEventListener('click', handler);
-    });
-    dropdownNavLists.forEach(dropdown => {
-      const handler = dropdownNavListsHandlers.shift();
-      dropdown.children[1].removeEventListener('keydown', handler);
-    });
-    // eslint-disable-next-line no-undef
-    document.querySelectorAll('.js-back-button').forEach(backButton => {
-      const handler = goBackOneLevelHandlers.shift();
-      backButton.removeEventListener('click', handler);
-    });
-  };
-
-  const useResizeListener = () => {
-    // hide side navigation drawer when screen is resized horizontally
-    /* eslint-disable */
-    let previousWidth = window.innerWidth;
-    window.addEventListener(
-      'resize',
-      debounce(() => {
-        const currentWidth = window.innerWidth;
-        if (currentWidth !== previousWidth) {
-          closeAllDropdowns();
-          previousWidth = currentWidth;
-        }
-        if (currentWidth >= breakpoint) {
-          // deactivate sliding navigation listeners because we are in desktop mode
-          removeListeners();
-          // make sure we display the scroll bar if it was hidden
-          document.body.style.overflow = 'visible';
-        } else {
-          // activate sliding navigation listeners
-          addListeners();
-        }
-      }, 10)
-    );
-    /* eslint-enable */
   };
 
   // when clicking outside navigation, close all dropdowns
@@ -336,6 +285,5 @@ export const setUpListeners = (
 
   return {
     addListeners,
-    useResizeListener,
   };
 };

--- a/src/js/sliding/sliding-nav.js
+++ b/src/js/sliding/sliding-nav.js
@@ -18,11 +18,9 @@ export const initNavigationSliding = (
   const { closeDesktopGlobalNav } = useDesktopListeners();
   desktopResizeListener(breakpoint);
 
-  const { addListeners, useResizeListener } = setUpListeners(
-    breakpoint,
+  const addListeners = setUpListeners(
     closeDesktopGlobalNav,
     closeMenuAnimationDuration || DEFAULT_CLOSE_MENU_ANIMATION_DURATION
   );
   addListeners();
-  useResizeListener();
 };

--- a/src/sass/global-nav.scss
+++ b/src/sass/global-nav.scss
@@ -335,7 +335,7 @@ $box-shadow-color: hsla(0, 0%, 100%, 0.1);
 // sass-lint:disable no-ids
 #all-canonical-mobile {
   .global-nav__header-link-anchor::after {
-    right: map-get($grid-margin-widths, default);
+    right: map-get($grid-margin-widths, small);
 
     @media (max-width: $global-nav-breakpoint) {
       right: 1rem;


### PR DESCRIPTION
## Done

Fix bug: on resizing, the listeners for clicks were removed.
Fix styling: on medium screens the styles for the 'all-canonical-links' arrows were slightly misaligned compared with the others that have the default styles coming from Vanilla Framework.

## How to QA

You can check a sample normal and sliding navigations on [Demos](https://global-nav-292.demos.haus/).
Try to resize the window and check that the navigation dropdown still work.
On medium screens (620 - 1024 px) check that the sliding menu has all the arrows (>) aligned.

## Issue / Card

Fixes [WD-26280](https://warthogs.atlassian.net/browse/WD-26280)

[WD-26280]: https://warthogs.atlassian.net/browse/WD-26280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ