### PR TITLE
WD-26684 - Remove display of empty dropdown container

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,8 @@
   "rules": {
     "import/prefer-default-export": 0,
     "implicit-arrow-linebreak": "off"
+  },
+  "env": {
+    "browser": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -11,6 +11,7 @@ export const createNav = ({
   desktopContainerSelector,
   isSliding = false,
   closeMenuAnimationDuration,
+  dropdownAnimationDuration,
 } = {}) => {
   // Recruitment call to action
   // eslint-disable-next-line no-console
@@ -73,7 +74,11 @@ export const createNav = ({
   }
 
   if (isSliding) {
-    initNavigationSliding(breakpoint, closeMenuAnimationDuration);
+    initNavigationSliding(
+      breakpoint,
+      closeMenuAnimationDuration,
+      dropdownAnimationDuration,
+    );
   } else {
     initNavigationSimple(breakpoint);
   }

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -77,7 +77,7 @@ export const createNav = ({
     initNavigationSliding(
       breakpoint,
       closeMenuAnimationDuration,
-      dropdownAnimationDuration,
+      dropdownAnimationDuration
     );
   } else {
     initNavigationSimple(breakpoint);

--- a/src/js/sliding/listeners.js
+++ b/src/js/sliding/listeners.js
@@ -70,16 +70,24 @@ const collapseDropdown = (
   animated = false,
   animationDuration = ANIMATION_SNAP_DURATION
 ) => {
-  const closeHandler = () => {
-    targetDropdown.setAttribute('aria-hidden', 'true');
-    setActiveDropdown(dropdownToggleButton, false);
+  const dropdownToggleEl = dropdownToggleButton.closest(
+    '.p-navigation__item--dropdown-toggle'
+  );
+
+  const endAnimation = () => {
+    dropdownToggleEl.classList.toggle('js-animation-playing', false);
   };
 
-  if (animated) {
-    setTimeout(closeHandler, animationDuration);
-  } else {
-    closeHandler();
+  if (animated && dropdownToggleEl) {
+    dropdownToggleEl.classList.toggle('js-animation-playing', true);
+    setTimeout(endAnimation, animationDuration);
   }
+
+  // once the js-animation-playing has been set then we start the animation
+  window.requestAnimationFrame(() => {
+    targetDropdown.setAttribute('aria-hidden', 'true');
+    setActiveDropdown(dropdownToggleButton, false);
+  });
 };
 
 const expandDropdown = (
@@ -88,22 +96,31 @@ const expandDropdown = (
   animated = false,
   animationDuration = ANIMATION_SNAP_DURATION
 ) => {
-  const expandHandler = () => {
+  const dropdownToggleEl = dropdownToggleButton.closest(
+    '.p-navigation__item--dropdown-toggle'
+  );
+
+  const endAnimation = () => {
+    dropdownToggleEl.classList.toggle('js-animation-playing', false);
+  };
+
+  if (animated && dropdownToggleEl) {
+    dropdownToggleEl.classList.toggle('js-animation-playing', true);
+    setTimeout(endAnimation, animationDuration);
+  }
+
+  // once the js-animation-playing has been set then we start the animation
+  window.requestAnimationFrame(() => {
     setActiveDropdown(dropdownToggleButton);
     targetDropdown.setAttribute('aria-hidden', 'false');
     setFocusable(targetDropdown);
-  };
-
-  if (animated) {
-    setTimeout(expandHandler, animationDuration);
-  } else {
-    expandHandler();
-  }
+  });
 };
 
 export const setUpListeners = (
   closeDesktopGlobalNav,
-  closeMenuAnimationDuration
+  closeMenuAnimationDuration = ANIMATION_SNAP_DURATION,
+  dropdownAnimationDuration = ANIMATION_SNAP_DURATION,
 ) => {
   /* eslint-disable */
   const navigation = document.querySelector(
@@ -135,7 +152,7 @@ export const setUpListeners = (
       if (!target || target === excludedToggle) {
         return;
       }
-      collapseDropdown(toggle, target, animated);
+      collapseDropdown(toggle, target, animated, dropdownAnimationDuration);
     });
   };
 
@@ -145,8 +162,8 @@ export const setUpListeners = (
     const closeMenuHandler = () => {
       navigation.classList.remove('has-menu-open');
       navigation.classList.remove('menu-closing');
-      resetToggles();
     };
+    resetToggles(null, true);
 
     // the time is aproximately the time of the sliding animation
     setTimeout(closeMenuHandler, closeMenuAnimationDuration);
@@ -230,10 +247,10 @@ export const setUpListeners = (
 
       if (target.getAttribute('aria-hidden') === 'true') {
         unfocusAllLinks();
-        expandDropdown(toggle, target, true);
+        expandDropdown(toggle, target, true, dropdownAnimationDuration);
         navigation.classList.add('has-menu-open');
       } else {
-        collapseDropdown(toggle, target, true);
+        collapseDropdown(toggle, target, true, dropdownAnimationDuration);
         if (!isNested) {
           navigation.classList.remove('has-menu-open');
         }

--- a/src/js/sliding/listeners.js
+++ b/src/js/sliding/listeners.js
@@ -120,7 +120,7 @@ const expandDropdown = (
 export const setUpListeners = (
   closeDesktopGlobalNav,
   closeMenuAnimationDuration = ANIMATION_SNAP_DURATION,
-  dropdownAnimationDuration = ANIMATION_SNAP_DURATION,
+  dropdownAnimationDuration = ANIMATION_SNAP_DURATION
 ) => {
   /* eslint-disable */
   const navigation = document.querySelector(

--- a/src/js/sliding/sliding-nav.js
+++ b/src/js/sliding/sliding-nav.js
@@ -9,18 +9,20 @@ The sliding navigation is meant only for mobile.
 That's why we add also the desktop listeners.
 */
 
-const DEFAULT_CLOSE_MENU_ANIMATION_DURATION = 100;
+const DEFAULT_ANIMATION_DURATION = 100;
 
 export const initNavigationSliding = (
   breakpoint,
-  closeMenuAnimationDuration
+  closeMenuAnimationDuration,
+  dropdownAnimationDuration,
 ) => {
   const { closeDesktopGlobalNav } = useDesktopListeners();
   desktopResizeListener(breakpoint);
 
   const addListeners = setUpListeners(
     closeDesktopGlobalNav,
-    closeMenuAnimationDuration || DEFAULT_CLOSE_MENU_ANIMATION_DURATION
+    closeMenuAnimationDuration || DEFAULT_ANIMATION_DURATION,
+    dropdownAnimationDuration || DEFAULT_ANIMATION_DURATION,
   );
   addListeners();
 };

--- a/src/js/sliding/sliding-nav.js
+++ b/src/js/sliding/sliding-nav.js
@@ -14,7 +14,7 @@ const DEFAULT_ANIMATION_DURATION = 100;
 export const initNavigationSliding = (
   breakpoint,
   closeMenuAnimationDuration,
-  dropdownAnimationDuration,
+  dropdownAnimationDuration
 ) => {
   const { closeDesktopGlobalNav } = useDesktopListeners();
   desktopResizeListener(breakpoint);
@@ -22,7 +22,7 @@ export const initNavigationSliding = (
   const addListeners = setUpListeners(
     closeDesktopGlobalNav,
     closeMenuAnimationDuration || DEFAULT_ANIMATION_DURATION,
-    dropdownAnimationDuration || DEFAULT_ANIMATION_DURATION,
+    dropdownAnimationDuration || DEFAULT_ANIMATION_DURATION
   );
   addListeners();
 };

--- a/test/sliding.html
+++ b/test/sliding.html
@@ -69,11 +69,15 @@
           position: absolute;
         }
 
-        #navigation.p-navigation--sliding .js-animation-playing .p-navigation__dropdown--container {
+        #navigation.p-navigation--sliding
+          .js-animation-playing
+          .p-navigation__dropdown--container {
           display: block;
         }
 
-        #navigation.p-navigation--sliding .is-active .p-navigation__dropdown--container {
+        #navigation.p-navigation--sliding
+          .is-active
+          .p-navigation__dropdown--container {
           display: block;
         }
 

--- a/test/sliding.html
+++ b/test/sliding.html
@@ -64,9 +64,17 @@
 
         #navigation.p-navigation--sliding .p-navigation__dropdown--container {
           clip-path: rect(0 105% 105% 0);
-          display: block;
+          display: none;
           min-width: 100%;
           position: absolute;
+        }
+
+        #navigation.p-navigation--sliding .js-animation-playing .p-navigation__dropdown--container {
+          display: block;
+        }
+
+        #navigation.p-navigation--sliding .is-active .p-navigation__dropdown--container {
+          display: block;
         }
 
         #navigation.p-navigation--sliding
@@ -260,6 +268,7 @@
       canonicalGlobalNav.createNav({
         isSliding: true,
         closeMenuAnimationDuration: 200,
+        dropdownAnimationDuration: 333,
       });
     </script>
   </body>


### PR DESCRIPTION
## Done

Add `.js-animation-playing` class to global-nav in order to be able to set styles during sliding transition/animation.
Update example to show how to use this new class.

## How to QA

- Open [Demos](https://global-nav-295.demos.haus/test/sliding.html).
- Open/Close a dropdown from the menu in Desktop view.
- Open the Developer tools and inspect the dropdown menu while it is closed.
- The container should not be present in the page.
- Check that the menus in Mobile view still work as expected.

## Issue / Card

Fixes [WD-26684](https://warthogs.atlassian.net/browse/WD-26684)

[WD-26684]: https://warthogs.atlassian.net/browse/WD-26684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ