### PR TITLE
feat(WD-36517): add prominent Careers CTA on global nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/global-nav",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "A script and stylesheet that displays the Canonical global nav across the top of a site",
   "main": "dist/module.js",
   "iife": "dist/global-nav.js",

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -43,13 +43,13 @@ function createMobileDropdown(products) {
   const mobileDropdown = `<li id="all-canonical-mobile" class="u-hide">
     <ul class="p-navigation__items">
       <li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle">
-        <button href="#products" class="p-navigation__link global-nav__header-link-anchor">Products</button>
+        <button href="#products" class="p-navigation__link">Products</button>
         <ul id="products" class="p-navigation__dropdown">
           ${mobileFlagships}
         </ul>
       </li>
       <li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle">
-        <button href="#join-canonical" class="p-navigation__link global-nav__header-link-anchor">Join Canonical</button>
+        <button href="#join-canonical" class="p-navigation__link">Join Canonical</button>
         <ul id="join-canonical" class="p-navigation__dropdown">
           <li class="p-navigation__dropdown-item">
           <p>Be part of the team that builds the products.</p>
@@ -60,13 +60,13 @@ function createMobileDropdown(products) {
         </ul>
       </li>
       <li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle">
-        <button href="#also-from-canonical" class="p-navigation__link global-nav__header-link-anchor">Also from Canonical</button>
+        <button href="#also-from-canonical" class="p-navigation__link">Also from Canonical</button>
         <ul id="also-from-canonical" class="p-navigation__dropdown">
           ${mobileOthers}
         </ul>
       </li>
       <li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle">
-        <button href="#about" class="p-navigation__link global-nav__header-link-anchor">About</button>
+        <button href="#about" class="p-navigation__link">About</button>
         <ul id="about" class="p-navigation__dropdown u-no-margin--bottom">
           ${mobileAbouts}
         </ul>
@@ -241,7 +241,7 @@ function showAppropriateNavigation(breakpoint) {
 function addListeners(wrapper, breakpoint) {
   const primaryDropdownCTA = wrapper.querySelector('#all-canonical-link');
   const globalNavHeaderLinks = wrapper.querySelectorAll(
-    '.global-nav__dropdown-toggle .global-nav__header-link-anchor'
+    '.global-nav__dropdown-toggle'
   );
   /* eslint-disable */
   const externalNavDropdowns = document.querySelectorAll(
@@ -379,7 +379,7 @@ export const createNav = ({
 
   const navItem =
     createFromHTML(`<li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle u-hide" id="all-canonical">
-      <button href="#canonical-products" aria-controls="canonical-products" class="p-navigation__link global-nav__header-link-anchor" id="all-canonical-link" aria-expanded="false">All Canonical</button>
+      <button href="#canonical-products" aria-controls="canonical-products" class="p-navigation__link" id="all-canonical-link" aria-expanded="false">All Canonical</button>
     </li>`);
 
   const mobileDropdownHTML = createMobileDropdown(canonicalProducts);

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -49,6 +49,17 @@ function createMobileDropdown(products) {
         </ul>
       </li>
       <li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle">
+        <button href="#join-canonical" class="p-navigation__link global-nav__header-link-anchor">Join Canonical</button>
+        <ul id="join-canonical" class="p-navigation__dropdown">
+          <li class="p-navigation__dropdown-item">
+          <p>Be a part of the team that builds the products.</p>
+            <div class="p-cta-block">
+              <a href="https://canonical.com/careers" class="p-button--positive">Search open roles</a>
+            </div>
+          </li>
+        </ul>
+      </li>
+      <li class="p-navigation__item--dropdown-toggle global-nav__dropdown-toggle">
         <button href="#also-from-canonical" class="p-navigation__link global-nav__header-link-anchor">Also from Canonical</button>
         <ul id="also-from-canonical" class="p-navigation__dropdown">
           ${mobileOthers}
@@ -152,7 +163,7 @@ function createProductDropdown(products) {
 
   const productAbouts = abouts
     .map(about => {
-      const aboutMarkup = `<li class="global-nav__list-item">
+      const aboutMarkup = `<li class="p-inline-list__item">
           <a class="global-nav__link" href=${about.url}>${about.title}</a>
         </li>`;
       return aboutMarkup;
@@ -167,17 +178,33 @@ function createProductDropdown(products) {
 
         <hr class="p-divider" />
 
-        <div class="global-nav__flex-container row u-no-padding">
+        <div class="global-nav__flex-container row p-section--shallow u-no-padding--left">
+          <div class="col-3 col-medium-2">
+            <span class="global-nav__muted-heading">Join Canonical</span>
+            <div class="global-nav__matrix">
+              <div class="global-nav__matrix-item u-no-padding--bottom">
+                <p class="global-nav__join-desc">Be a part of the team that builds the products.</p>
+              </div>
+            </div>
+            <div class="p-cta-block">
+              <a href="https://canonical.com/careers" class="p-button--positive">Search open roles</a>
+            </div>
+          </div>
+          <hr class="p-divider u-hide--large" />
           <div class="global-nav__others-col col-9 col-medium-6">
             <span class="global-nav__muted-heading">Also from Canonical</span>
             <div class="global-nav__matrix">
               ${productOthers}
             </div>
           </div>
-          <hr class="p-divider u-hide--large" />
+        </div>
+        <hr class="p-divider" />
+        <div class="global-nav__flex-container row p-section--shallow u-no-padding--left">
           <div class="global-nav__about-col col-3 col-medium-2">
             <span class="global-nav__muted-heading">About</span>
-            <ul class="global-nav__list">
+          </div>
+          <div class="global-nav__others-col col-9 col-medium-6">
+            <ul class="p-inline-list">
               ${productAbouts}
             </ul>
           </div>

--- a/src/js/global-nav.js
+++ b/src/js/global-nav.js
@@ -52,7 +52,7 @@ function createMobileDropdown(products) {
         <button href="#join-canonical" class="p-navigation__link global-nav__header-link-anchor">Join Canonical</button>
         <ul id="join-canonical" class="p-navigation__dropdown">
           <li class="p-navigation__dropdown-item">
-          <p>Be a part of the team that builds the products.</p>
+          <p>Be part of the team that builds the products.</p>
             <div class="p-cta-block">
               <a href="https://canonical.com/careers" class="p-button--positive">Search open roles</a>
             </div>
@@ -172,9 +172,11 @@ function createProductDropdown(products) {
 
   const productDropdown = `<div class="global-nav__strip">
       <div class="global-nav__row is-bordered">
-        <ul class="p-list--divided u-sv3">
-          ${productFlagships}
-        </ul>
+        <div class="p-section--shallow">
+          <ul class="p-list--divided u-no-margin">
+            ${productFlagships}
+          </ul>
+        </div>
 
         <hr class="p-divider" />
 
@@ -183,7 +185,7 @@ function createProductDropdown(products) {
             <span class="global-nav__muted-heading">Join Canonical</span>
             <div class="global-nav__matrix">
               <div class="global-nav__matrix-item u-no-padding--bottom">
-                <p class="global-nav__join-desc">Be a part of the team that builds the products.</p>
+                <p class="global-nav__join-desc">Be part of the team that builds the products.</p>
               </div>
             </div>
             <div class="p-cta-block">

--- a/src/js/product-details.js
+++ b/src/js/product-details.js
@@ -12,7 +12,7 @@ const canonicalProducts = {
       logoUrl:
         'data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20fill%3D%27none%27%20viewBox%3D%270%200%2016%2016%27%3E%3Cpath%20fill-rule%3D%27evenodd%27%20clip-rule%3D%27evenodd%27%20d%3D%27M13.864%202.244a2.244%202.244%200%201%201-4.489-.002%202.244%202.244%200%200%201%204.489.002ZM4.49%207.17A2.244%202.244%200%201%201%200%207.169a2.244%202.244%200%200%201%204.489.001Zm2.83%205.787a5.484%205.484%200%200%201-3.738-2.848%203.226%203.226%200%200%201-1.924.239%207.328%207.328%200%200%200%205.269%204.413c.522.11%201.063.165%201.594.165a3.241%203.241%200%200%201-.66-1.877l-.07-.011c-.153-.024-.312-.049-.47-.08Zm6.03.01a2.244%202.244%200%201%201-4.488-.002%202.244%202.244%200%200%201%204.488.002Zm.89-.825a7.35%207.35%200%200%200%20.367-8.626A3.215%203.215%200%200%201%2013.34%205a5.557%205.557%200%200%201%20.523%203.736%205.544%205.544%200%200%201-.697%201.74%203.184%203.184%200%200%201%201.072%201.666ZM2.15%203.942a1.007%201.007%200%200%201-.08.005A7.402%207.402%200%200%201%209.044.238a3.173%203.173%200%200%200-.614%201.319c-.027.165-.055.33-.064.503a5.508%205.508%200%200%200-4.417%202.363%203.352%203.352%200%200%200-1.026-.412%203.343%203.343%200%200%200-.678-.073c-.033%200-.064.002-.094.004Z%27%20fill%3D%27%23E95420%27%2F%3E%3C%2Fsvg%3E',
       description:
-        "The world's favourite Linux OS for servers, desktops and IoT.",
+        "The world's favorite Linux OS for servers, desktops and IoT.",
     },
     {
       title: 'Ubuntu Pro',
@@ -93,7 +93,7 @@ const canonicalProducts = {
     {
       title: 'Ubuntu on public clouds',
       url: 'https://ubuntu.com/download/cloud',
-      description: 'Optimised Ubuntu for public clouds.',
+      description: 'Optimized Ubuntu for public clouds.',
     },
     {
       title: 'Multipass',
@@ -103,7 +103,7 @@ const canonicalProducts = {
     {
       title: 'Cloud-init',
       url: 'https://cloud-init.io/',
-      description: 'Control and customise your cloud instances.',
+      description: 'Control and customize your cloud instances.',
     },
     {
       title: 'Landscape',
@@ -113,7 +113,7 @@ const canonicalProducts = {
     {
       title: 'Netplan',
       url: 'http://www.netplan.io/',
-      description: 'Simplify and standardise complex network configuration.',
+      description: 'Simplify and standardize complex network configuration.',
     },
     {
       title: 'Charmed Kubeflow',
@@ -132,7 +132,7 @@ const canonicalProducts = {
       url: 'https://canonical.com/',
     },
     {
-      title: 'Press centre',
+      title: 'Press center',
       url: 'https://canonical.com/press-centre',
     },
     {

--- a/src/sass/global-nav.scss
+++ b/src/sass/global-nav.scss
@@ -30,41 +30,6 @@ $box-shadow-color: hsla(0, 0%, 100%, 0.1);
     &::after {
       display: none;
     }
-
-    .global-nav__header-link-anchor {
-      &::after {
-        @include vf-icon-chevron;
-
-        background-position: center;
-        background-repeat: no-repeat;
-        background-size: contain;
-        content: '';
-        display: block;
-        height: $spv--large;
-        pointer-events: none;
-        position: absolute;
-        right: map-get($grid-margin-widths, small);
-        text-indent: calc(100% + 10rem);
-        top: calc(#{$spv--large} + #{map-get($nudges, x-small)});
-        width: map-get($icon-sizes, default);
-
-        .is-dark & {
-          @include vf-icon-chevron($colors--dark-theme--text-default);
-        }
-
-        @media (min-width: $threshold-4-6-col) {
-          right: calc(#{$sph--small} + 1px);
-        }
-      }
-
-      &.is-selected {
-        background-color: $colors--dark-theme--background-hover;
-
-        &::after {
-          transform: rotate(180deg);
-        }
-      }
-    }
   }
 }
 
@@ -329,17 +294,6 @@ $box-shadow-color: hsla(0, 0%, 100%, 0.1);
   &.show-overlay {
     opacity: 1;
     pointer-events: all;
-  }
-}
-
-// sass-lint:disable no-ids
-#all-canonical-mobile {
-  .global-nav__header-link-anchor::after {
-    right: map-get($grid-margin-widths, default);
-
-    @media (max-width: $global-nav-breakpoint) {
-      right: 1rem;
-    }
   }
 }
 

--- a/src/sass/global-nav.scss
+++ b/src/sass/global-nav.scss
@@ -176,6 +176,11 @@ $box-shadow-color: hsla(0, 0%, 100%, 0.1);
       padding: 1rem 0;
       width: 100%;
     }
+
+    .global-nav__join-desc {
+      color: $colors--dark-theme--text-default;
+      padding-top: 0.45rem;
+    }
   }
 
   .global-nav__matrix-image {
@@ -217,11 +222,6 @@ $box-shadow-color: hsla(0, 0%, 100%, 0.1);
     @media (max-width: $global-nav-breakpoint) {
       display: none;
     }
-  }
-
-  .global-nav__about-col {
-    border-left: 1px solid $global-nav-border-color;
-    padding-left: 1rem;
   }
 
   .global-nav__list {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5019,10 +5019,10 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
-vanilla-framework@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.9.0.tgz#7566b42a22c2394ea1d7ea843d24ec305446cb3e"
-  integrity sha512-iTmvqWlsX0ic69VZ1sR9NPQtYRR9+iM679HZCl7SDQhMQSsEeJEQ6Ejjen3JN5a7YxiYmeIhxaLlmC4rExRT1w==
+vanilla-framework@4.35.0:
+  version "4.35.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.35.0.tgz#b01bbb525ad3211690c9f10580ca2e00a37a8ab1"
+  integrity sha512-vF8M9vsXiOpJEonFXiTVhY0rXOzNtoWpkhBcCVpyPb4+oHBx0/FaNcX5GAiQpfdT6Q/AAeRYyWwRUDObq6R8uw==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Done

- Added careers CTA on global nav
- Updated package version
- (drive by): Fixed content chevron misalignment

### QA

- Checkout the [demo](https://ubuntu-com-16454.demos.haus/)
- Verify the global nav dropdown opens, and "Join Canonical" section matches [figma](https://www.figma.com/design/BSP7FqnRMcMvO7kCozJKUa/26.10-Ubuntu.com-navigation-update-Iteration-9---Vanilla?node-id=6774-6046&t=WD0aneXfdN5jaBjH-1)

Fixes [WD-36517](https://warthogs.atlassian.net/browse/WD-36517) [WD-37173](https://warthogs.atlassian.net/browse/WD-37173)

[WD-36517]: https://warthogs.atlassian.net/browse/WD-36517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-37173]: https://warthogs.atlassian.net/browse/WD-37173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ